### PR TITLE
add toggleSortReferences on load if true

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@samepage/external": "^0.28.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -330,7 +330,9 @@ export default runExtension({
       onloadArgs
     );
     const toggleSortReferences = runSortReferences();
-    if (!!extensionAPI.settings.get("sort-references")) {toggleSortReferences(true);}
+    if (!!extensionAPI.settings.get("sort-references")) {
+      toggleSortReferences(true);
+    }
     
     const globalRefs = {
       clearOnClick: ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -330,7 +330,8 @@ export default runExtension({
       onloadArgs
     );
     const toggleSortReferences = runSortReferences();
-
+    if (!!extensionAPI.settings.get("sort-references")) {toggleSortReferences(true);}
+    
     const globalRefs = {
       clearOnClick: ({
         parentUid,


### PR DESCRIPTION
related to https://github.com/dvargas92495/roamjs-query-builder/issues/22

@dvargas92495, could it be the case that `runSortReferences()` isn't being called on load?

`if (!!extensionAPI.settings.get("sort-references")) {toggleSortReferences(true);}`
seemed to fix it when testing with `Reload Developer Extensions`