### PR TITLE
getEnglishQuery change output number toString

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "MIT",
       "dependencies": {
         "@samepage/external": "^0.28.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/utils/fireQuery.ts
+++ b/src/utils/fireQuery.ts
@@ -553,6 +553,8 @@ const getEnglishQuery = (args: FireQueryArgs) => {
                   Object.entries(output).forEach(([k, v]) => {
                     p[label + k] = v;
                   });
+                } else if (typeof output === "number") {
+                  p[label] = output.toString();
                 } else {
                   p[label] = output;
                 }


### PR DESCRIPTION
**Issue this is addressing**
Unable to filter [Discourse Graph Attributes](https://oasis-lab.gitbook.io/roamresearch-discourse-graph-extension/guides/exploring-your-discourse-graph/discourse-attributes)

Although this does fix the Discourse Graph Attribute issue, I haven't put a lot of thought into other possible negative downstream effects.  I tested a regular Attribute that had numbers and a regex selection of numbers, both worked.

Before
![image](https://user-images.githubusercontent.com/3792666/215001678-10dd2f83-5920-478a-9d6d-05b9898ca0d5.png)

After
![image](https://user-images.githubusercontent.com/3792666/215001718-eb807002-a8d6-4ab1-92c9-b72051baa62b.png)
