### PR TITLE
Sort ref bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "MIT",
       "dependencies": {
         "@samepage/external": "^0.28.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/utils/runSortReferences.ts
+++ b/src/utils/runSortReferences.ts
@@ -184,8 +184,12 @@ const runSortReferences = () => {
       ) => {
         const sidebarWindow = sortContainer.closest(".rm-sidebar-window");
         const currentPageUID = await window.roamAlphaAPI.ui.mainWindow.getOpenPageOrBlockUid();
+        const allSidebarWindows = document.body.querySelectorAll(".rm-sidebar-window");
+        const sidebarWindowIndex = Array.from(allSidebarWindows).indexOf(sidebarWindow);
+        const sidebarWindowData = window.roamAlphaAPI.ui.rightSidebar.getWindows()[sidebarWindowIndex]
         const pageUID = !!sidebarWindow
-          ? getPageUidByPageTitle(sidebarWindow.querySelector("div > a").textContent)
+        //  @ts-ignore Roam has an API inconsistency - https://roamresearch.slack.com/archives/C02TMKXNVS6/p1676389252784269
+          ? sidebarWindowData["page-uid"] || sidebarWindowData["mentions-uid"]
           : !currentPageUID
           ? getPageUidByPageTitle(getPageTitleValueByHtmlElement(sortContainer))
           : currentPageUID;

--- a/src/utils/runSortReferences.ts
+++ b/src/utils/runSortReferences.ts
@@ -2,7 +2,6 @@ import getFullTreeByParentUid from "roamjs-components/queries/getFullTreeByParen
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import getPageTitleValueByHtmlElement from "roamjs-components/dom/getPageTitleValueByHtmlElement";
 import getPageTitlesReferencingBlockUid from "roamjs-components/queries/getPageTitlesReferencingBlockUid";
-import getCurrentPageUid from "roamjs-components/dom/getCurrentPageUid";
 import createOverlayObserver from "roamjs-components/dom/createOverlayObserver";
 import createIconButton from "roamjs-components/dom/createIconButton";
 
@@ -176,18 +175,20 @@ const runSortReferences = () => {
         return node.substring(attr.length + 2).trim();
       };
 
-      const menuItemCallback = (
+      const menuItemCallback = async (
         sortContainer: Element,
         sortBy: (
           a: { title: string; time: number },
           b: { title: string; time: number }
         ) => number
       ) => {
-        const currentPageUID = getCurrentPageUid();
-        const pageUID = 
-          /^([0-9]{2}-){2}[0-9]{4}$/.test(currentPageUID)  
-            ? getPageUidByPageTitle(getPageTitleValueByHtmlElement(sortContainer))
-            : currentPageUID
+        const sidebarWindow = sortContainer.closest(".rm-sidebar-window");
+        const currentPageUID = await window.roamAlphaAPI.ui.mainWindow.getOpenPageOrBlockUid();
+        const pageUID = !!sidebarWindow
+          ? getPageUidByPageTitle(sidebarWindow.querySelector("div > a").textContent)
+          : !currentPageUID
+          ? getPageUidByPageTitle(getPageTitleValueByHtmlElement(sortContainer))
+          : currentPageUID;
         if (!pageUID) {
           return;
         }

--- a/src/utils/runSortReferences.ts
+++ b/src/utils/runSortReferences.ts
@@ -1,7 +1,8 @@
 import getFullTreeByParentUid from "roamjs-components/queries/getFullTreeByParentUid";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import getPageTitleValueByHtmlElement from "roamjs-components/dom/getPageTitleValueByHtmlElement";
-import getLinkedPageReferences from "roamjs-components/queries/getPageTitleReferencesByPageTitle";
+import getPageTitlesReferencingBlockUid from "roamjs-components/queries/getPageTitlesReferencingBlockUid";
+import getCurrentPageUid from "roamjs-components/dom/getCurrentPageUid";
 import createOverlayObserver from "roamjs-components/dom/createOverlayObserver";
 import createIconButton from "roamjs-components/dom/createIconButton";
 
@@ -182,11 +183,15 @@ const runSortReferences = () => {
           b: { title: string; time: number }
         ) => number
       ) => {
-        const pageTitle = getPageTitleValueByHtmlElement(sortContainer);
-        if (!pageTitle) {
+        const currentPageUID = getCurrentPageUid();
+        const pageUID = 
+          /^([0-9]{2}-){2}[0-9]{4}$/.test(currentPageUID)  
+            ? getPageUidByPageTitle(getPageTitleValueByHtmlElement(sortContainer))
+            : currentPageUID
+        if (!pageUID) {
           return;
         }
-        const linkedReferences = getLinkedPageReferences(pageTitle).map(
+        const linkedReferences = getPageTitlesReferencingBlockUid(pageUID).map(
           (title) => ({
             title,
             time:


### PR DESCRIPTION
@dvargas92495 for [Sort References Bug](https://roamresearch.slack.com/archives/C016N2B66JU/p1675448161078559)

`getPageTitleValueByHtmlElement(sortContainer)` is still required for Daily Notes Page
`getCurrentPageUid()` returns today's date on DNP which is what `/^([0-9]{2}-){2}[0-9]{4}$/.test(currentPageUID)` is looking for.
I feel like this isn't ideal, and it gives a false positive for any day page, but that code still works regardless on those pages.

also `npm version patch` errored, but still went to 1.1.8

![image](https://user-images.githubusercontent.com/3792666/216731196-bdb45ee6-ec62-4caf-bb42-4ead2a5f1aab.png)
