### PR TITLE
add @ for sources

### DIFF
--- a/src/utils/compileDatalog.ts
+++ b/src/utils/compileDatalog.ts
@@ -4,7 +4,7 @@ import type {
   DatalogClause,
 } from "roamjs-components/types/native";
 
-const toVar = (v = "undefined") => v.replace(/[\s"()[\]{}/\\^]/g, "");
+const toVar = (v = "undefined") => v.replace(/[\s"()[\]{}/\\^@]/g, "");
 
 const compileDatalog = (
   d:


### PR DESCRIPTION
Query for Discourse Sources failed.

```
[:find
  (pull ?node [:block/string :node/title :block/uid])
  (pull ?node [:block/uid])
:where
  [(re-pattern "^@(.*?)$") ?@.*?$-regex]
  [?node :node/title ?node-Title]
  [(re-find ?@.*?$-regex ?node-Title)]
]
```

Error message was: `Invalid character: @ found while reading symbol.`

