### PR TITLE
Supporting Inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@samepage/external": "^0.52.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -27,11 +27,7 @@ import AutocompleteInput from "roamjs-components/components/AutocompleteInput";
 import getNthChildUidByBlockUid from "roamjs-components/queries/getNthChildUidByBlockUid";
 import getChildrenLengthByPageUid from "roamjs-components/queries/getChildrenLengthByPageUid";
 import parseQuery from "../utils/parseQuery";
-import {
-  backendToken,
-  getDatalogQuery,
-  getDatalogQueryComponents,
-} from "../utils/fireQuery";
+import { backendToken, getDatalogQuery } from "../utils/fireQuery";
 import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
 import {
   Condition,
@@ -588,13 +584,11 @@ const QueryEditor: QueryEditorComponent = ({
                 order: 1,
               });
               if (enabled) {
-                const text = getDatalogQuery(
-                  getDatalogQueryComponents({
-                    conditions,
-                    selections,
-                    returnNode,
-                  })
-                );
+                const { query: text } = getDatalogQuery({
+                  conditions,
+                  selections,
+                  returnNode,
+                });
                 if (contentUid) updateBlock({ text, uid: contentUid });
                 else
                   createBlock({

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -23,7 +23,7 @@ import createBlock from "roamjs-components/writes/createBlock";
 import extractTag from "roamjs-components/util/extractTag";
 import Export from "./Export";
 import parseQuery from "../utils/parseQuery";
-import { getDatalogQuery, getDatalogQueryComponents } from "../utils/fireQuery";
+import { getDatalogQuery } from "../utils/fireQuery";
 import getCurrentUserUid from "roamjs-components/queries/getCurrentUserUid";
 import type { Result } from "roamjs-components/types/query-builder";
 import parseResultSettings from "../utils/parseResultSettings";
@@ -278,7 +278,7 @@ const toCellValue = (v: number | Date | string) =>
 const QueryUsed = ({ parentUid }: { parentUid: string }) => {
   const { datalogQuery, englishQuery } = useMemo(() => {
     const args = parseQuery(parentUid);
-    const datalogQuery = getDatalogQuery(getDatalogQueryComponents(args));
+    const { query: datalogQuery } = getDatalogQuery(args);
     const englishQuery = [
       `Find ${args.returnNode} Where`,
       ...(args.conditions as QBClauseData[]).map(

--- a/src/utils/conditionToDatalog.ts
+++ b/src/utils/conditionToDatalog.ts
@@ -7,19 +7,9 @@ import endOfDay from "date-fns/endOfDay";
 import type { DatalogClause, PullBlock } from "roamjs-components/types";
 import { Condition } from "./types";
 
-type RegisterDatalogTranslator = (args: {
-  key: string;
-  callback: (args: {
-    source: string;
-    target: string;
-    uid: string;
-  }) => DatalogClause[];
-  targetOptions?: string[] | ((source: string) => string[]);
-  placeholder?: string;
-  isVariable?: true;
-}) => void;
-
 type ConditionToDatalog = (condition: Condition) => DatalogClause[];
+
+const INPUT_REGEX = /^:in /;
 
 const getTitleDatalog = ({
   source,
@@ -115,14 +105,14 @@ const getTitleDatalog = ({
       },
     ];
   }
-  if (/^:in /.test(target)) {
+  if (INPUT_REGEX.test(target)) {
     return [
       {
         type: "data-pattern",
         arguments: [
           { type: "variable", value: source },
           { type: "constant", value: ":node/title" },
-          { type: "variable", value: target.replace(/^:in /, "") },
+          { type: "variable", value: target.replace(INPUT_REGEX, "") },
         ],
       },
     ];
@@ -547,51 +537,119 @@ const translator: Record<string, Translator> = {
     placeholder: "Enter any natural language date value",
   },
   "titled before": {
-    callback: ({ source, target }) => [
-      {
+    callback: ({ source, target }) => {
+      const sourceLog: DatalogClause = {
         type: "data-pattern",
         arguments: [
           { type: "variable", value: source },
           { type: "constant", value: ":log/id" },
           { type: "variable", value: `${source}-Log` },
         ],
-      },
-      {
-        type: "pred-expr",
-        pred: ">",
-        arguments: [
-          {
-            type: "constant",
-            value: `${startOfDay(parseNlpDate(target)).valueOf()}`,
-          },
-          { type: "variable", value: `${source}-Log` },
-        ],
-      },
-    ],
+      };
+      return INPUT_REGEX.test(target)
+        ? [
+            sourceLog,
+            {
+              type: "data-pattern",
+              arguments: [
+                { type: "variable", value: `${target}-Date` },
+                { type: "constant", value: ":node/title" },
+                { type: "variable", value: target.replace(INPUT_REGEX, "") },
+              ],
+            },
+            {
+              type: "data-pattern",
+              arguments: [
+                { type: "variable", value: `${target}-Date` },
+                { type: "constant", value: ":log/id" },
+                { type: "variable", value: `${target}-Log` },
+              ],
+            },
+            {
+              type: "pred-expr",
+              pred: ">",
+              arguments: [
+                {
+                  type: "variable",
+                  value: `${target}-Log`,
+                },
+                { type: "variable", value: `${source}-Log` },
+              ],
+            },
+          ]
+        : [
+            sourceLog,
+            {
+              type: "pred-expr",
+              pred: ">",
+              arguments: [
+                {
+                  type: "constant",
+                  value: `${startOfDay(parseNlpDate(target)).valueOf()}`,
+                },
+                { type: "variable", value: `${source}-Log` },
+              ],
+            },
+          ];
+    },
     placeholder: "Enter any natural language date value",
   },
   "titled after": {
-    callback: ({ source, target }) => [
-      {
+    callback: ({ source, target }) => {
+      const sourceLog: DatalogClause = {
         type: "data-pattern",
         arguments: [
           { type: "variable", value: source },
           { type: "constant", value: ":log/id" },
           { type: "variable", value: `${source}-Log` },
         ],
-      },
-      {
-        type: "pred-expr",
-        pred: "<",
-        arguments: [
-          {
-            type: "constant",
-            value: `${endOfDay(parseNlpDate(target)).valueOf()}`,
-          },
-          { type: "variable", value: `${source}-Log` },
-        ],
-      },
-    ],
+      };
+      return INPUT_REGEX.test(target)
+        ? [
+            sourceLog,
+            {
+              type: "data-pattern",
+              arguments: [
+                { type: "variable", value: `${target}-Date` },
+                { type: "constant", value: ":node/title" },
+                { type: "variable", value: target.replace(INPUT_REGEX, "") },
+              ],
+            },
+            {
+              type: "data-pattern",
+              arguments: [
+                { type: "variable", value: `${target}-Date` },
+                { type: "constant", value: ":log/id" },
+                { type: "variable", value: `${target}-Log` },
+              ],
+            },
+            {
+              type: "pred-expr",
+              pred: "<",
+              arguments: [
+                {
+                  type: "variable",
+                  value: `${target}-Log`,
+                },
+                { type: "variable", value: `${source}-Log` },
+              ],
+            },
+          ]
+        : [
+            sourceLog,
+            {
+              type: "pred-expr",
+              pred: "<",
+              arguments: [
+                {
+                  type: "constant",
+                  value: `${endOfDay(parseNlpDate(target)).valueOf()}`,
+                },
+                { type: "variable", value: `${source}-Log` },
+              ],
+            },
+          ];
+    },
     placeholder: "Enter any natural language date value",
   },
 };

--- a/src/utils/conditionToDatalog.ts
+++ b/src/utils/conditionToDatalog.ts
@@ -115,6 +115,18 @@ const getTitleDatalog = ({
       },
     ];
   }
+  if (/^:in /.test(target)) {
+    return [
+      {
+        type: "data-pattern",
+        arguments: [
+          { type: "variable", value: source },
+          { type: "constant", value: ":node/title" },
+          { type: "variable", value: target.replace(/^:in /, "") },
+        ],
+      },
+    ];
+  }
   return [
     {
       type: "data-pattern",

--- a/src/utils/fireQuery.ts
+++ b/src/utils/fireQuery.ts
@@ -606,7 +606,7 @@ const fireQuery: FireQuery = async (args) => {
   try {
     if (getNodeEnv() === "development") {
       console.log("Query to Roam:");
-      console.log(query);
+      console.log(query, ...inputs);
     }
     return args.isBackendEnabled && backendToken
       ? apiPost<{ result: PullBlock[][] }>({

--- a/src/utils/runQuery.ts
+++ b/src/utils/runQuery.ts
@@ -1,14 +1,19 @@
 import type { OnloadArgs } from "roamjs-components/types/native";
-import fireQuery from "./fireQuery";
+import fireQuery, { QueryArgs } from "./fireQuery";
 import parseQuery from "./parseQuery";
 import parseResultSettings from "./parseResultSettings";
 import postProcessResults from "./postProcessResults";
 
-const runQuery = (
-  parentUid: string,
-  extensionAPI: OnloadArgs["extensionAPI"]
-) => {
-  const queryArgs = parseQuery(parentUid);
+const runQuery = ({
+  parentUid,
+  extensionAPI,
+  inputs,
+}: {
+  parentUid: string;
+  extensionAPI: OnloadArgs["extensionAPI"];
+  inputs?: QueryArgs["inputs"];
+}) => {
+  const queryArgs = Object.assign(parseQuery(parentUid), { inputs });
   return fireQuery(queryArgs).then((results) => {
     const settings = parseResultSettings(
       parentUid,


### PR DESCRIPTION
If you want to create a backlog for multiple clients or users, you need to create separate query builder instances for each one.

This allows users to only have one query builder instance that can be used across multiple values for a particular field.

We're starting with the SB use case, but I still need to go through all of the usages of `fireQuery` to see what can apply.

Adding you to the PR now for visibility, no need for review yet