### PR TITLE
add comma to toVar for pages with commas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@samepage/external": "^0.52.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/utils/compileDatalog.ts
+++ b/src/utils/compileDatalog.ts
@@ -4,7 +4,7 @@ import type {
   DatalogClause,
 } from "roamjs-components/types/native";
 
-const toVar = (v = "undefined") => v.replace(/[\s"()[\]{}/\\^@]/g, "");
+const toVar = (v = "undefined") => v.replace(/[\s"()[\]{}/\\^@,]/g, "");
 
 const compileDatalog = (
   d:


### PR DESCRIPTION
`Cannot compare :block/parents to page`

`?April13th,2023`

```
[:find
  (pull ?node [:block/string :node/title :block/uid])
  (pull ?node [:block/uid])
:where
  [?April13th,2023 :node/title "April 13th, 2023"]
  [?node :block/page ?April13th,2023]
]
```