### PR TITLE
Exploring ideas around custom view types in graph

### DIFF
--- a/src/components/MessageBlock.tsx
+++ b/src/components/MessageBlock.tsx
@@ -1,76 +1,64 @@
-import { Card, Spinner } from "@blueprintjs/core";
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import fireQuery from "../utils/fireQuery";
-import parseQuery from "../utils/parseQuery";
-import type { Result } from "roamjs-components/types/query-builder";
-import ResultsView from "./ResultsView";
-import ReactDOM from "react-dom";
-import QueryEditor from "./QueryEditor";
+import { Button, Card } from "@blueprintjs/core";
+import React, { useMemo } from "react";
 import getSubTree from "roamjs-components/util/getSubTree";
-import { createComponentRender } from "roamjs-components/components/ComponentContainer";
 import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
-import createBlock from "roamjs-components/writes/createBlock";
-import deleteBlock from "roamjs-components/writes/deleteBlock";
-import setInputSetting from "roamjs-components/util/setInputSetting";
-import { OnloadArgs } from "roamjs-components/types/native";
-import ExtensionApiContextProvider, {
-  useExtensionAPI,
-} from "roamjs-components/components/ExtensionApiContext";
-import { Filters } from "roamjs-components/components/Filter";
-import { ExportTypes } from "../utils/types";
-import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
+import { OnloadArgs, PullBlock } from "roamjs-components/types/native";
 import renderWithUnmount from "roamjs-components/util/renderWithUnmount";
+import getBlockUidsReferencingBlock from "roamjs-components/queries/getBlockUidsReferencingBlock";
 
 type QueryPageComponent = (props: { blockUid: string }) => JSX.Element;
 
 type Props = Parameters<QueryPageComponent>[0];
 
 const MessageBlock = ({ blockUid }: Props) => {
-  const extensionAPI = useExtensionAPI();
-  const hideMetadata = useMemo(
-    () => !!extensionAPI && !!extensionAPI.settings.get("hide-metadata"),
-    [extensionAPI]
-  );
-  const tree = useMemo(() => getBasicTreeByParentUid(blockUid), [blockUid]);
-  const { subject, from, when } = useMemo(() => {
-    const pull = window.roamAlphaAPI.pull(
-      "[:block/string :create/user :create/time]",
-      [":block/uid", blockUid]
-    );
-    const fromPage = window.roamAlphaAPI.pull(
-      "[:user/display-page]",
-      pull[":create/user"]?.[":db/id"] || 0
-    )?.[":user/display-page"]?.[":db/id"];
-    const from =
-      window.roamAlphaAPI.pull("[:node/title]", fromPage || 0)?.[
-        ":node/title"
-      ] || "";
-    return {
-      subject: pull[":block/string"] || "",
-      from,
-      when: new Date(pull[":create/time"] || 0),
+  const thread = useMemo(() => {
+    const allBlockUidsInThread = new Set([blockUid]);
+    const getMessageInfo = (uid: string) => {
+      const tree = getBasicTreeByParentUid(uid);
+      const pull = window.roamAlphaAPI.pull(
+        "[:block/string :create/user :create/time]",
+        [":block/uid", uid]
+      );
+      const fromPage = window.roamAlphaAPI.pull(
+        "[:user/display-page]",
+        pull[":create/user"]?.[":db/id"] || 0
+      )?.[":user/display-page"]?.[":db/id"];
+      const from =
+        window.roamAlphaAPI.pull("[:node/title]", fromPage || 0)?.[
+          ":node/title"
+        ] || "";
+      const subject = pull[":block/string"] || "";
+      const when = new Date(pull[":create/time"] || 0);
+      const recipients = getSubTree({ tree, key: "to::" })
+        .children.map((c) => /#([^\s]+)\s+\[\[([^\]]+)\]\]/.exec(c.text))
+        .filter((s): s is RegExpExecArray => !!s)
+        .map(([_, to, status]) => ({ to, status }));
+      const body = getSubTree({ tree, key: "body::" }).children[0].text;
+      return { subject, from, when, body, recipients };
     };
+    const getReplies = (uid: string): string[] => {
+      const referringUids = getBlockUidsReferencingBlock(uid).filter(
+        (u) => u && !allBlockUidsInThread.has(u)
+      );
+      referringUids.forEach((u) => allBlockUidsInThread.add(u));
+      return [uid, ...referringUids.flatMap(getReplies)];
+    };
+    const getAncestors = (uid: string): string[] => {
+      const refs = (
+        window.roamAlphaAPI.data.fast.q(
+          `[:find (pull ?ref [:block/uid]) :where [?block :block/uid ${uid}] [?block :block/refs ?ref]]`
+        ) as [PullBlock][]
+      )
+        .map((r) => r[0]?.[":block/uid"])
+        .filter((u): u is string => !!u && !allBlockUidsInThread.has(u));
+      refs.forEach((u) => allBlockUidsInThread.add(u));
+      return [...refs.flatMap(getAncestors), uid];
+    };
+    const ancestors = getAncestors(blockUid);
+    const replies = getReplies(blockUid);
+    const uids = [...ancestors.slice(0, -1), blockUid, ...replies.slice(1)];
+    return uids.map(getMessageInfo);
   }, [blockUid]);
-  const to = useMemo(
-    () =>
-      getSubTree({ tree, key: "to::" })
-        .children.map((c) => /#([^\s]+)\s/.exec(c.text)?.[1])
-        .filter((s): s is string => !!s),
-    [tree]
-  );
-  const body = useMemo(
-    () => getSubTree({ tree, key: "body::" }).children[0].text,
-    [tree]
-  );
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
-  const [results, setResults] = useState<Result[]>([]);
   return (
     <Card
       id={`roamjs-message-block-${blockUid}`}
@@ -79,25 +67,54 @@ const MessageBlock = ({ blockUid }: Props) => {
       <style>{`div[data-roamjs-message-block=true] .rm-block-children {
   display: none;
 }`}</style>
-      <h1>{subject}</h1>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}
-      >
-        <div>
-          <b className="block mb-2">{from}</b>
-          <span className="text-small text-gray-200">to {to.join(", ")}</span>
+      <h1>{thread[0].subject}</h1>
+      {thread.map((t, i) => (
+        <div className="hover:bg-opacity-75 roamjs-message" key={i}>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
+            <div>
+              <b className="block mb-1">{t.from}</b>
+              <span style={{ fontSize: 12 }}>
+                to{" "}
+                {t.recipients
+                  .map((r) => `${r.to}${/unread/i.test(r.status) ? "*" : ""}`)
+                  .join(", ")}
+              </span>
+            </div>
+            <div style={{ fontSize: 12, alignSelf: "end" }}>
+              {t.when.toLocaleString()}
+            </div>
+          </div>
+          <div className="pt-2 pb-4">{t.body}</div>
         </div>
-        <div>
-          <span className="text-small text-gray-200">
-            {when.toLocaleString()}
-          </span>
-        </div>
+      ))}
+      <div className="flex gap-4">
+        <Button
+          icon={
+            <img
+              src="https://raw.githubusercontent.com/dvargas92495/roamjs-smartblocks/main/src/img/lego3blocks.png"
+              height={16}
+              width={16}
+            />
+          }
+          text="Mark Read"
+        />
+        <Button
+          icon={
+            <img
+              src="https://raw.githubusercontent.com/dvargas92495/roamjs-smartblocks/main/src/img/lego3blocks.png"
+              height={16}
+              width={16}
+            />
+          }
+          text="Reply"
+        />
       </div>
-      <div>{body}</div>
     </Card>
   );
 };

--- a/src/components/MessageBlock.tsx
+++ b/src/components/MessageBlock.tsx
@@ -1,0 +1,118 @@
+import { Card, Spinner } from "@blueprintjs/core";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import fireQuery from "../utils/fireQuery";
+import parseQuery from "../utils/parseQuery";
+import type { Result } from "roamjs-components/types/query-builder";
+import ResultsView from "./ResultsView";
+import ReactDOM from "react-dom";
+import QueryEditor from "./QueryEditor";
+import getSubTree from "roamjs-components/util/getSubTree";
+import { createComponentRender } from "roamjs-components/components/ComponentContainer";
+import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
+import createBlock from "roamjs-components/writes/createBlock";
+import deleteBlock from "roamjs-components/writes/deleteBlock";
+import setInputSetting from "roamjs-components/util/setInputSetting";
+import { OnloadArgs } from "roamjs-components/types/native";
+import ExtensionApiContextProvider, {
+  useExtensionAPI,
+} from "roamjs-components/components/ExtensionApiContext";
+import { Filters } from "roamjs-components/components/Filter";
+import { ExportTypes } from "../utils/types";
+import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
+import renderWithUnmount from "roamjs-components/util/renderWithUnmount";
+
+type QueryPageComponent = (props: { blockUid: string }) => JSX.Element;
+
+type Props = Parameters<QueryPageComponent>[0];
+
+const MessageBlock = ({ blockUid }: Props) => {
+  const extensionAPI = useExtensionAPI();
+  const hideMetadata = useMemo(
+    () => !!extensionAPI && !!extensionAPI.settings.get("hide-metadata"),
+    [extensionAPI]
+  );
+  const tree = useMemo(() => getBasicTreeByParentUid(blockUid), [blockUid]);
+  const { subject, from, when } = useMemo(() => {
+    const pull = window.roamAlphaAPI.pull(
+      "[:block/string :create/user :create/time]",
+      [":block/uid", blockUid]
+    );
+    const fromPage = window.roamAlphaAPI.pull(
+      "[:user/display-page]",
+      pull[":create/user"]?.[":db/id"] || 0
+    )?.[":user/display-page"]?.[":db/id"];
+    const from =
+      window.roamAlphaAPI.pull("[:node/title]", fromPage || 0)?.[
+        ":node/title"
+      ] || "";
+    return {
+      subject: pull[":block/string"] || "",
+      from,
+      when: new Date(pull[":create/time"] || 0),
+    };
+  }, [blockUid]);
+  const to = useMemo(
+    () =>
+      getSubTree({ tree, key: "to::" })
+        .children.map((c) => /#([^\s]+)\s/.exec(c.text)?.[1])
+        .filter((s): s is string => !!s),
+    [tree]
+  );
+  const body = useMemo(
+    () => getSubTree({ tree, key: "body::" }).children[0].text,
+    [tree]
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [results, setResults] = useState<Result[]>([]);
+  return (
+    <Card
+      id={`roamjs-message-block-${blockUid}`}
+      className={"roamjs-message-block pt-0 px-4 pb-4 overflow-auto"}
+    >
+      <style>{`div[data-roamjs-message-block=true] .rm-block-children {
+  display: none;
+}`}</style>
+      <h1>{subject}</h1>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div>
+          <b className="block mb-2">{from}</b>
+          <span className="text-small text-gray-200">to {to.join(", ")}</span>
+        </div>
+        <div>
+          <span className="text-small text-gray-200">
+            {when.toLocaleString()}
+          </span>
+        </div>
+      </div>
+      <div>{body}</div>
+    </Card>
+  );
+};
+
+export const render = ({
+  parent,
+  onloadArgs,
+  ...props
+}: { parent: HTMLElement; onloadArgs: OnloadArgs } & Props) => {
+  parent.onmousedown = (e) => e.stopPropagation();
+  const root = parent.closest(".roam-block-container");
+  if (root) {
+    root.setAttribute("data-roamjs-message-block", "true");
+  }
+  return renderWithUnmount(<MessageBlock {...props} />, parent, onloadArgs);
+};
+
+export default MessageBlock;


### PR DESCRIPTION
Roam has this concept of Changing Block View:
<img width="431" alt="Screen Shot 2023-05-04 at 12 42 47 PM" src="https://user-images.githubusercontent.com/7143571/236535773-3a7bcfe2-9ce7-4c5d-9fbb-852d6c132769.png">

This brain blasted me into thinking we should allow users to create their own custom views of data to replace other pieces of UI.

This is one such use case. For now, the component is very specific. But in SamePage, we will want to allow users to create their own UIs instead, similar to smartblocks and queries. Ongoing, SB and QB will continue to serve as testing beds for ideas we want to generalize into SamePage

I wouldn't try to set this up locally (again, it's very custom to a specific user), but would rather review the idea and ask related questions if there are any