### PR TITLE
Add column hiding functionality

### DIFF
--- a/src/utils/parseResultSettings.ts
+++ b/src/utils/parseResultSettings.ts
@@ -114,6 +114,10 @@ const parseResultSettings = (
     tree: resultNode.children,
     key: "layout",
   });
+  const hiddenColumnsNode = getSubTree({
+    tree: resultNode.children,
+    key: "hiddenColumns",
+  });
   const layout = Object.fromEntries(
     layoutNode.children
       .filter((c) => c.children.length)
@@ -161,6 +165,7 @@ const parseResultSettings = (
         savedViewData[column]?.mode || (column === "text" ? "link" : "plain"),
       value: savedViewData[column]?.value || "",
     })),
+    hiddenColumns: hiddenColumnsNode.children.map((c) => c.text),
     random,
     pageSize,
     layout,


### PR DESCRIPTION
Add the ability to hide columns in the results view, with settings persisted as blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the ability to hide and show columns in the results view, with a dedicated "Hide Columns" menu option and an editing panel for toggling column visibility.
  * Column visibility settings are saved and persist across sessions.

* **Improvements**
  * All table, chart, timeline, and kanban views now respect hidden columns, ensuring only visible columns are shown in filters, exports, and view selectors.
  * The menu icon now indicates when columns are hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->