### PR TITLE
Fix query embed rendering with Roam React components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.37.0",
+      "version": "1.37.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "react-draggable": "^4.4.5",
         "react-in-viewport": "^1.0.0-alpha.20",
         "react-vertical-timeline-component": "^3.5.2",
-        "roamjs-components": "^0.83.4",
+        "roamjs-components": "^0.88.1",
         "signia-react": "^0.1.1"
       },
       "devDependencies": {
@@ -8147,13 +8147,13 @@
       }
     },
     "node_modules/roamjs-components": {
-      "version": "0.83.4",
-      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.83.4.tgz",
-      "integrity": "sha512-NdLQnKZtRaUQ10JVgK05sZFlylXLd+dSdtBfFJgaELBEfV0IykM8dxW2qZ1e8No+XCzOn+q58fwHe6YHcePXNw==",
+      "version": "0.88.1",
+      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.88.1.tgz",
+      "integrity": "sha512-AnL+30xUDRKPfmoUQyS5FTAEUwNAGzqyTYTNzDzDZbD9bYSJCguS43eOwUYXI66gAHYgul4xiZuUtNWxKwmLpg==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@samepage/scripts": "^0.74.2",
-        "aws-sdk-plus": "^0.5.3",
         "color": "^4.0.1",
         "date-fns": "^2.27.0",
         "edn-data": "^1.0.0",
@@ -15805,12 +15805,11 @@
       }
     },
     "roamjs-components": {
-      "version": "0.83.4",
-      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.83.4.tgz",
-      "integrity": "sha512-NdLQnKZtRaUQ10JVgK05sZFlylXLd+dSdtBfFJgaELBEfV0IykM8dxW2qZ1e8No+XCzOn+q58fwHe6YHcePXNw==",
+      "version": "0.88.1",
+      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.88.1.tgz",
+      "integrity": "sha512-AnL+30xUDRKPfmoUQyS5FTAEUwNAGzqyTYTNzDzDZbD9bYSJCguS43eOwUYXI66gAHYgul4xiZuUtNWxKwmLpg==",
       "requires": {
         "@samepage/scripts": "^0.74.2",
-        "aws-sdk-plus": "^0.5.3",
         "color": "^4.0.1",
         "date-fns": "^2.27.0",
         "edn-data": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-draggable": "^4.4.5",
     "react-in-viewport": "^1.0.0-alpha.20",
     "react-vertical-timeline-component": "^3.5.2",
-    "roamjs-components": "^0.83.4",
+    "roamjs-components": "^0.88.1",
     "signia-react": "^0.1.1"
   },
   "overrides": {

--- a/src/components/Export.tsx
+++ b/src/components/Export.tsx
@@ -423,7 +423,7 @@ const ExportDialog: ExportDialogComponent = ({
                 if (event.shiftKey) {
                   window.roamAlphaAPI.ui.rightSidebar.addWindow({
                     window: {
-                      "block-uid": uid,
+                      "page-uid": uid,
                       type: "outline",
                     },
                   });

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -31,26 +31,18 @@ import { Sorts } from "../utils/parseResultSettings";
 import getRoamUrl from "roamjs-components/dom/getRoamUrl";
 
 const zPriority = z.record(z.number().min(0).max(1));
+const { Block: RenderRoamBlock } = window.roamAlphaAPI.ui.react;
 
 type Reprioritize = (args: { uid: string; x: number; y: number }) => void;
 
 const BlockEmbed = ({ uid, viewValue }: { uid: string; viewValue: string }) => {
   const title = getPageTitleByPageUid(uid);
-  const contentRef = useRef(null);
   const open =
-    viewValue === "open" ? true : viewValue === "closed" ? false : null;
-  useEffect(() => {
-    const el = contentRef.current;
-    if (el) {
-      window.roamAlphaAPI.ui.components.renderBlock({
-        uid,
-        el,
-        // "open?": open, // waiting for roamAlphaAPI to add a open/close to renderBlock
-      });
-    }
-  }, [uid, open, contentRef]);
+    viewValue === "open" ? true : viewValue === "closed" ? false : undefined;
   return (
-    <div ref={contentRef} className={!!title ? "page-embed" : "block-embed"} />
+    <div className={!!title ? "page-embed" : "block-embed"}>
+      <RenderRoamBlock uid={uid} open={open} />
+    </div>
   );
 };
 

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -30,28 +30,15 @@ import { ContextContent } from "./DiscourseContext";
 
 const EXTRA_ROW_TYPES = ["context", "discourse"] as const;
 type ExtraRowType = (typeof EXTRA_ROW_TYPES)[number] | null;
+const { Block: RenderRoamBlock, Page: RenderRoamPage } =
+  window.roamAlphaAPI.ui.react;
 
 const ExtraContextRow = ({ uid }: { uid: string }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!containerRef.current) return;
-    if (getPageTitleByPageUid(uid)) {
-      window.roamAlphaAPI.ui.components.renderPage({
-        uid,
-        el: containerRef.current,
-        hideMentions: true,
-      });
-    } else {
-      window.roamAlphaAPI.ui.components.renderBlock({
-        uid,
-        el: containerRef.current,
-        zoomPath: true,
-      });
-    }
-  }, [containerRef, uid]);
-
-  return <div ref={containerRef} />;
+  return getPageTitleByPageUid(uid) ? (
+    <RenderRoamPage uid={uid} hideMentions />
+  ) : (
+    <RenderRoamBlock uid={uid} zoomPath />
+  );
 };
 
 const dragImage = document.createElement("img");
@@ -166,25 +153,13 @@ const ResultHeader = React.forwardRef<
 
 const CellEmbed = ({ uid, viewValue }: { uid: string; viewValue: string }) => {
   const title = getPageTitleByPageUid(uid);
-  const contentRef = useRef(null);
-  useEffect(() => {
-    const el = contentRef.current;
-    const open =
-      viewValue === "open" ? true : viewValue === "closed" ? false : null;
-    if (el) {
-      window.roamAlphaAPI.ui.components.renderBlock({
-        uid,
-        el,
-        // "open?": open, // waiting for roamAlphaAPI to add a open/close to renderBlock
-      });
-    }
-  }, [contentRef]);
+  const open =
+    viewValue === "open" ? true : viewValue === "closed" ? false : undefined;
   return (
     <div className="roamjs-query-embed">
-      <div
-        ref={contentRef}
-        className={!!title ? "page-embed" : "block-embed"}
-      />
+      <div className={!!title ? "page-embed" : "block-embed"}>
+        <RenderRoamBlock uid={uid} open={open} />
+      </div>
     </div>
   );
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -580,7 +580,6 @@ svg.rs-svg-container {
       ).then((blockUid) =>
         queryRender({
           blockUid,
-          clearOnClick,
           onloadArgs,
         })
       ),

--- a/src/utils/getExportTypes.ts
+++ b/src/utils/getExportTypes.ts
@@ -42,6 +42,9 @@ const pullBlockToTreeNode = (n: PullBlock, v: `:${ViewType}`): TreeNode => ({
   uid: n[":block/uid"] || "",
   heading: n[":block/heading"] || 0,
   viewType: (n[":children/view-type"] || v).slice(1) as ViewType,
+  blockViewType: (n[":block/view-type"] || ":vertical").slice(
+    1
+  ) as TreeNode["blockViewType"],
   editTime: new Date(n[":edit/time"] || 0),
   props: { imageResize: {}, iframe: {} },
   textAlign: n[":block/text-align"] || "left",


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/roamjs/query-builder/pull/327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar context association when shift-clicking to send results to the right sidebar—now correctly associates with page UID instead of block UID

* **Improvements**
  * Block view type information is now preserved during export operations

* **Chores**
  * Updated roamjs-components dependency to v0.88.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->