### PR TITLE
Refactor QueryPage rendering to use renderWithUnmount utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-builder",
-  "version": "1.37.1",
+  "version": "1.37.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "query-builder",
-      "version": "1.37.1",
+      "version": "1.37.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-builder",
-  "version": "1.37.1",
+  "version": "1.37.2",
   "description": "Introduces new user interfaces for building queries in Roam",
   "main": "./build/main.js",
   "author": {

--- a/src/components/QueryPage.tsx
+++ b/src/components/QueryPage.tsx
@@ -10,17 +10,15 @@ import fireQuery from "../utils/fireQuery";
 import parseQuery from "../utils/parseQuery";
 import type { Result } from "roamjs-components/types/query-builder";
 import ResultsView from "./ResultsView";
-import ReactDOM from "react-dom";
 import QueryEditor from "./QueryEditor";
 import getSubTree from "roamjs-components/util/getSubTree";
 import { createComponentRender } from "roamjs-components/components/ComponentContainer";
+import renderWithUnmount from "roamjs-components/util/renderWithUnmount";
 import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
 import createBlock from "roamjs-components/writes/createBlock";
 import deleteBlock from "roamjs-components/writes/deleteBlock";
 import { OnloadArgs } from "roamjs-components/types/native";
-import ExtensionApiContextProvider, {
-  useExtensionAPI,
-} from "roamjs-components/components/ExtensionApiContext";
+import { useExtensionAPI } from "roamjs-components/components/ExtensionApiContext";
 import { Column, ExportTypes } from "../utils/types";
 
 type QueryPageComponent = (props: {
@@ -200,11 +198,6 @@ export const render = ({
   onloadArgs,
   ...props
 }: { parent: HTMLElement; onloadArgs: OnloadArgs } & Props) =>
-  ReactDOM.render(
-    <ExtensionApiContextProvider {...onloadArgs}>
-      <QueryPage {...props} />
-    </ExtensionApiContextProvider>,
-    parent
-  );
+  renderWithUnmount(<QueryPage {...props} />, parent, onloadArgs);
 
 export default QueryPage;


### PR DESCRIPTION
- Removed ReactDOM.render in favor of renderWithUnmount for improved component lifecycle management.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/roamjs/query-builder/pull/328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->