### PR TITLE
Fix multi-value attribute cells rendering with page-ref brackets

### DIFF
--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -190,6 +190,7 @@ const ResultRow = ({
     const value = toCellValue({
       value: r[`${key}-display`] || r[key] || "",
       uid: (r[`${key}-uid`] as string) || "",
+      stripRefs: true,
     });
     const action = r[`${key}-action`];
     if (typeof action === "string") {

--- a/src/utils/toCellValue.ts
+++ b/src/utils/toCellValue.ts
@@ -38,10 +38,12 @@ const toCellValue = ({
   value,
   uid,
   defaultValue = "",
+  stripRefs = false,
 }: {
   value: number | Date | string;
   defaultValue?: string;
   uid: string;
+  stripRefs?: boolean;
 }) => {
   const initialValue =
     value instanceof Date
@@ -62,7 +64,16 @@ const toCellValue = ({
             .join("/")
         : initialValue
       : initialValue;
-  return formattedValue;
+
+  // `extractTag` only unwraps a single, whole-string tag, so a multi-value
+  // attribute (e.g. `[[A]], [[B]]`) keeps its `[[ ]]` while a single value is
+  // unwrapped. When rendering for display, strip the page-ref delimiters from
+  // every remaining ref so multi-value cells read the same as single-value
+  // ones. Off by default so callers relying on the raw value (filtering,
+  // in-place edits) are unaffected.
+  return stripRefs
+    ? formattedValue.replace(/#?\[\[([^[\]]+)\]\]/g, "$1")
+    : formattedValue;
 };
 
 export default toCellValue;


### PR DESCRIPTION
### Problem
In Query Builder result tables a single-value attribute renders unwrapped (e.g. `[[A]]` → `A`), but a multi-value attribute keeps its brackets (e.g. `[[A]], [[B]]` → `[[A]], [[B]]`). The two are inconsistent.

### Cause
`toCellValue` cleans cell text with `extractTag`, which only unwraps a single, whole-string tag. For a multi-value string its guard sees the inner `]]` before the next `[[`, bails out, and returns the value unchanged — so the brackets stay.

### Fix
Add an opt-in `stripRefs` flag to `toCellValue` that strips the page-ref delimiters from every remaining ref, and pass it from the results-table display site (`ResultRow`'s `cell()`).

It is **off by default**, so callers that rely on the raw value are unchanged:
- the filter value set (`filterData`)
- Kanban column grouping / drag comparison
- the `references` in-place edit in `predefinedSelections` (`blockText.replace(toCellValue(...), value)`)

So this only changes how cells are *displayed* — not filtering, sorting, or editing.

### Before / After (display)
| value | before | after |
| --- | --- | --- |
| `[[A]]` | A | A |
| `[[A]], [[B]]` | `[[A]], [[B]]` | A, B |
